### PR TITLE
Get user info after obtaining the access token

### DIFF
--- a/lib/omniauth/strategies/adp_oauth2.rb
+++ b/lib/omniauth/strategies/adp_oauth2.rb
@@ -19,6 +19,25 @@ module OmniAuth
         :token_url     => '/auth/oauth/v2/token'
       }
 
+      uid do
+        raw_info['sub']
+      end
+
+      info do
+        {
+          name: raw_info['name'],
+          email: raw_info['email'],
+          first_name: raw_info['given_name'],
+          last_name: raw_info['family_name'],
+          organizationOID: raw_info['organizationOID'],
+          associateOID: raw_info['associateOID']
+        }
+      end
+
+      def raw_info
+        @raw_info ||= access_token.get(options[:client_options][:user_info_url]).parsed
+      end
+
       def authorize_params
         super.tap do |params|
           options[:authorize_options].each do |k|


### PR DESCRIPTION
After a successful authentication, an access token is obtained. Using that token, an additional call is needed to get the actual user info from ADP.

Provide the `user_info_url` in `initializers/omniauth.rb`.

```ruby
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :adp_oauth2,
           ...
           client_options: {
             ...
             user_info_url: 'https://api.adp.com/core/v1/userinfo',
             ...
           }
```